### PR TITLE
Remove untrusted CORS proxy fallback from API fetches

### DIFF
--- a/script.js
+++ b/script.js
@@ -91,12 +91,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     async function fetchWithCorsFallback(url, options = {}) {
-        try {
-            return await fetch(url, options);
-        } catch (error) {
-            const proxyUrl = `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`;
-            return await fetch(proxyUrl, options);
-        }
+        return await fetch(url, options);
     }
 
     // --- State ---


### PR DESCRIPTION
### Motivation
- Remove the previously added untrusted CORS proxy retry that routed failed API requests through `https://api.allorigins.win/raw?url=...`, which exposed query terms and allowed a third-party to tamper with or observe API responses used to populate UI content and outbound links.

### Description
- Replace the previous fallback logic in `fetchWithCorsFallback` with a single direct `fetch(url, options)` call, preserving existing call sites while eliminating reliance on the `api.allorigins.win` proxy.

### Testing
- Ran `node --check script.js` to validate basic syntax and it completed successfully.
- Verified removal of the proxy by searching for `allorigins` in `script.js` and confirming no references remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d58a5370832eb0a879c5f6e46271)