### PR TITLE
Neutralize CSV formula injection in export by sanitizing cell values

### DIFF
--- a/script.js
+++ b/script.js
@@ -495,19 +495,32 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function sanitizeCsvCell(value, maxLength = null) {
+        let sanitized = value == null ? '' : String(value);
+        if (typeof maxLength === 'number') {
+            sanitized = sanitized.substring(0, maxLength);
+        }
+
+        if (/^[=+\-@]/.test(sanitized)) {
+            sanitized = `'${sanitized}`;
+        }
+
+        return `"${sanitized.replace(/"/g, '""')}"`;
+    }
+
     function exportToCsv() {
         try {
             const headers = ['Title', 'Authors', 'Date', 'Categories', 'DOI', 'URL', 'Abstract'];
             const csvRows = [headers.join(',')];
             allPapers.forEach(paper => {
                 const row = [
-                    `"${(paper.title || '').replace(/"/g, '""')}"`,
-                    `"${Array.isArray(paper.authors) ? paper.authors.join('; ') : ''}"`,
-                    `"${paper.date || ''}"`,
-                    `"${paper.categories ? paper.categories.join('; ') : ''}"`,
-                    `"${paper.doi || ''}"`,
-                    `"${paper.url || ''}"`,
-                    `"${(paper.abstract || '').replace(/"/g, '""').substring(0, 500)}"`
+                    sanitizeCsvCell(paper.title || ''),
+                    sanitizeCsvCell(Array.isArray(paper.authors) ? paper.authors.join('; ') : ''),
+                    sanitizeCsvCell(paper.date || ''),
+                    sanitizeCsvCell(paper.categories ? paper.categories.join('; ') : ''),
+                    sanitizeCsvCell(paper.doi || ''),
+                    sanitizeCsvCell(paper.url || ''),
+                    sanitizeCsvCell(paper.abstract || '', 500)
                 ];
                 csvRows.push(row.join(','));
             });


### PR DESCRIPTION
### Motivation
- The CSV exporter previously serialized untrusted paper fields by only escaping double quotes and wrapping cells in quotes, which does not prevent spreadsheet apps from interpreting values starting with `=`, `+`, `-`, or `@` as formulas. 
- The goal is to neutralize potential CSV/Formula injection from external APIs or localStorage while preserving existing CSV formatting and truncation behavior.

### Description
- Add a `sanitizeCsvCell(value, maxLength = null)` helper that converts values to strings, applies optional truncation, prefixes a single quote for values starting with `=`, `+`, `-`, or `@`, and then doubles embedded quotes and wraps the cell in quotes. 
- Update `exportToCsv` to call `sanitizeCsvCell` for every column (including using a 500-character limit for abstracts), replacing the previous inline quote-escaping logic. 
- Preserve existing behavior of CSV escaping (double quotes) and abstract truncation while making a minimal, targeted change.

### Testing
- Ran `node --check script.js` to validate syntax and the change succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d4bb1c48832eb906fa8d1645f91d)