### PR TITLE
Sanitize cached paper links in authors/topics views

### DIFF
--- a/authors.js
+++ b/authors.js
@@ -14,6 +14,16 @@ document.addEventListener('DOMContentLoaded', () => {
         return unsafe.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
     }
 
+    function sanitizeUrl(url) {
+        if (!url || url === '#') return '#';
+        try {
+            const parsed = new URL(url);
+            return (parsed.protocol === 'https:' || parsed.protocol === 'http:') ? url : '#';
+        } catch {
+            return '#';
+        }
+    }
+
     function loadData() {
         try {
             const savedData = localStorage.getItem('foodAI-living-review');
@@ -141,8 +151,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 .forEach(paper => {
                     const link = document.createElement('a');
                     link.className = 'author-paper-link';
-                    link.href = paper.url && paper.url !== '#' ? paper.url : '#';
-                    if (paper.url && paper.url !== '#') {
+                    const safeUrl = sanitizeUrl(paper.url);
+                    link.href = safeUrl;
+                    if (safeUrl !== '#') {
                         link.target = '_blank';
                         link.rel = 'noopener noreferrer';
                     }

--- a/topics.js
+++ b/topics.js
@@ -13,6 +13,16 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function sanitizeUrl(url) {
+        if (!url || url === '#') return '#';
+        try {
+            const parsed = new URL(url);
+            return (parsed.protocol === 'https:' || parsed.protocol === 'http:') ? url : '#';
+        } catch {
+            return '#';
+        }
+    }
+
     function buildTopicIndex(papers) {
         const topicMap = new Map();
 
@@ -119,9 +129,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
                     const title = document.createElement('div');
                     title.className = 'topic-paper-title';
-                    if (paper.url && paper.url !== '#') {
+                    const safeUrl = sanitizeUrl(paper.url);
+                    if (safeUrl !== '#') {
                         const link = document.createElement('a');
-                        link.href = paper.url;
+                        link.href = safeUrl;
                         link.target = '_blank';
                         link.rel = 'noopener noreferrer';
                         link.textContent = paper.title;


### PR DESCRIPTION
### Motivation
- Authors and topics pages were assigning `paper.url` values from `localStorage` directly into anchor `href`, which allows `javascript:`/`data:` URLs from a poisoned cache to become clickable and cause unsafe navigation or script execution.
- The main library view already uses a `sanitizeUrl` pattern to restrict links to `http`/`https`, so the authors/topics views need the same minimal protection.

### Description
- Add a local `sanitizeUrl(url)` helper to `authors.js` and `topics.js` that returns the URL only for `http:`/`https:` schemes and otherwise returns `#`.
- Use the sanitized `safeUrl` when assigning `href` for author/topic paper links and only set `target`/`rel` when `safeUrl !== '#'`.
- Preserve existing behavior for valid external links so they still open in a new tab with `noopener noreferrer`.

### Testing
- Ran `node --check authors.js && node --check topics.js` and both files passed syntax checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94a5f67e4832e8f992ee8e01bffc5)